### PR TITLE
August update: Python 3.12.5 and 3.13.0rc1, openssl 3.3.1 + linting of .py

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  OPENSSL_VERSION: 3.3.0
+  OPENSSL_VERSION: 3.3.1
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_version: ["22.04", "24.04"]
-        python_version: ["3.11.9", "3.12.3", "3.13.0b1"]
+        python_version: ["3.11.9", "3.12.5", "3.13.0rc1"]
     env:
       UBUNTU_VERSION: ${{ matrix.ubuntu_version }}
       PYTHON_VERSION: ${{ matrix.python_version }}

--- a/.github/workflows/docker-image-quick-build.yml
+++ b/.github/workflows/docker-image-quick-build.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  OPENSSL_VERSION: 3.3.0
+  OPENSSL_VERSION: 3.3.1
   QUICK_BUILD: true
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_version: ["22.04", "24.04"]
-        python_version: ["3.11.9", "3.12.3", "3.13.0b1"]
+        python_version: ["3.11.9", "3.12.5", "3.13.0rc1"]
     env:
       UBUNTU_VERSION: ${{ matrix.ubuntu_version }}
       PYTHON_VERSION: ${{ matrix.python_version }}

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ and the latest openSSL.
 
 The images can be accessed using `docker pull <image name>`.
 
-| Ubuntu | Python   | Image name                     |
-| ------ | -------- | ------------------------------ |
-| 22.04  | 3.11.9   | ursamajorlab/jammy-python:3.11 |
-| 22.04  | 3.12.3   | ursamajorlab/jammy-python:3.12 |
-| 22.04  | 3.13.0b1 | ursamajorlab/jammy-python:3.13 |
-| 24.04  | 3.11.9   | ursamajorlab/noble-python:3.11 |
-| 24.04  | 3.12.3   | ursamajorlab/noble-python:3.12 |
-| 24.04  | 3.13.0b1 | ursamajorlab/noble-python:3.13 |
+| Ubuntu | Python    | Image name                     |
+| ------ | --------- | ------------------------------ |
+| 22.04  | 3.11.9    | ursamajorlab/jammy-python:3.11 |
+| 22.04  | 3.12.5    | ursamajorlab/jammy-python:3.12 |
+| 22.04  | 3.13.0rc1 | ursamajorlab/jammy-python:3.13 |
+| 24.04  | 3.11.9    | ursamajorlab/noble-python:3.11 |
+| 24.04  | 3.12.5    | ursamajorlab/noble-python:3.12 |
+| 24.04  | 3.13.0rc1 | ursamajorlab/noble-python:3.13 |
 
 The images are also accessible by using the major.minor.revision tag
 `ursamajorlab/<adjective>-python:<full-python-version>`,
-e.g. ursamajorlab/noble-python:3.12.3
+e.g. ursamajorlab/noble-python:3.12.5
 
 # Rationale
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y \
   wget \
   zlib1g-dev
 
-ARG OPENSSL_VERSION="3.3.0"
+ARG OPENSSL_VERSION="3.3.1"
 ARG QUICK_BUILD="false"
 ARG PY_VERSION
 

--- a/src/test_image.py
+++ b/src/test_image.py
@@ -1,12 +1,11 @@
-import os
+"""Test the image by making sure openssl is correctly linked."""
+
 import ssl
 
 import subprocess
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     openssl = subprocess.run(
-        ["/usr/local/ssl/bin/openssl", "version"],
-        capture_output=True,
-        text=True
+        ["/usr/local/ssl/bin/openssl", "version"], capture_output=True, text=True
     ).stdout
     assert ssl.OPENSSL_VERSION in openssl


### PR DESCRIPTION
August update: Python 3.12.5 and 3.13.0rc1, openssl 3.3.1 + linting of .py