### PR TITLE
Oct 2024 update

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -5,15 +5,15 @@ on:
     branches: [main]
 
 env:
-  OPENSSL_VERSION: 3.3.2
+  OPENSSL_VERSION: 3.4.0
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ubuntu_version: ["22.04", "24.04"]
-        python_version: ["3.11.10", "3.12.7", "3.13.0rc3"]
+        ubuntu_version: ["24.04", "24.10"]
+        python_version: ["3.11.10", "3.12.7", "3.13.0"]
     env:
       UBUNTU_VERSION: ${{ matrix.ubuntu_version }}
       PYTHON_VERSION: ${{ matrix.python_version }}

--- a/.github/workflows/docker-image-quick-build.yml
+++ b/.github/workflows/docker-image-quick-build.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  OPENSSL_VERSION: 3.3.2
+  OPENSSL_VERSION: 3.4.0
   QUICK_BUILD: true
 
 jobs:
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ubuntu_version: ["22.04", "24.04"]
-        python_version: ["3.11.10", "3.12.7", "3.13.0rc3"]
+        ubuntu_version: ["24.04", "24.10"]
+        python_version: ["3.11.10", "3.12.7", "3.13.0"]
     env:
       UBUNTU_VERSION: ${{ matrix.ubuntu_version }}
       PYTHON_VERSION: ${{ matrix.python_version }}

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ and the latest openSSL.
 
 The images can be accessed using `docker pull <image name>`.
 
-| Ubuntu | Python    | Image name                     |
-| ------ | --------- | ------------------------------ |
-| 22.04  | 3.11.10   | ursamajorlab/jammy-python:3.11 |
-| 22.04  | 3.12.7    | ursamajorlab/jammy-python:3.12 |
-| 22.04  | 3.13.0rc3 | ursamajorlab/jammy-python:3.13 |
-| 24.04  | 3.11.10   | ursamajorlab/noble-python:3.11 |
-| 24.04  | 3.12.7    | ursamajorlab/noble-python:3.12 |
-| 24.04  | 3.13.0rc3 | ursamajorlab/noble-python:3.13 |
+| Ubuntu | Python  | Image name                        |
+| ------ | ------- | --------------------------------- |
+| 24.04  | 3.11.10 | ursamajorlab/noble-python:3.11    |
+| 24.04  | 3.12.7  | ursamajorlab/noble-python:3.12    |
+| 24.04  | 3.13.0  | ursamajorlab/noble-python:3.13    |
+| 24.10  | 3.11.10 | ursamajorlab/oracular-python:3.11 |
+| 24.10  | 3.12.7  | ursamajorlab/oracular-python:3.12 |
+| 24.10  | 3.13.0  | ursamajorlab/oracular-python:3.13 |
 
 The images are also accessible by using the major.minor.revision tag
 `ursamajorlab/<adjective>-python:<full-python-version>`,

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y \
   wget \
   zlib1g-dev
 
-ARG OPENSSL_VERSION="3.3.2"
+ARG OPENSSL_VERSION="3.4.0"
 ARG QUICK_BUILD="false"
 ARG PY_VERSION
 


### PR DESCRIPTION
Oct 2024 update

- openSSL 3.4.0
- Python 3.13
- move to Oracular for non-LTS version